### PR TITLE
Refactor CreateServiceAsync to remove unnecessary async

### DIFF
--- a/DevOpsControlCenter.Tests/DevOpsConnectionServiceTests.cs
+++ b/DevOpsControlCenter.Tests/DevOpsConnectionServiceTests.cs
@@ -9,14 +9,14 @@ namespace DevOpsControlCenter.Tests;
 
 public class DevOpsConnectionServiceTests
 {
-    private async Task<DevOpsConnectionService> CreateServiceAsync()
+    private Task<DevOpsConnectionService> CreateServiceAsync()
     {
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString()) // isolated per test
             .Options;
 
         var factory = new PooledDbContextFactory<ApplicationDbContext>(options);
-        return new DevOpsConnectionService(factory);
+        return Task.FromResult(new DevOpsConnectionService(factory));
     }
 
     [Fact]


### PR DESCRIPTION
Refactor CreateServiceAsync to remove unnecessary async

Simplified the CreateServiceAsync method in the
DevOpsConnectionServiceTests class by removing the async
modifier and replacing the return statement with
Task.FromResult. This change eliminates the overhead of
an unnecessary state machine since the method does not
perform any asynchronous operations. Improves clarity
and aligns with best practices for methods returning
completed tasks.